### PR TITLE
fix: move SITE FILEtype=JES before upload (issue #9)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,10 @@ export class JobEntrySubsystem {
     try {
       await client.access(this.connectionOptions);
       // JCL is text; transfer in ASCII so the host performs EBCDIC translation.
+      // SITE must precede the upload so the STOR is handled as a JES submission.
       await client.send("TYPE A");
-      await client.uploadFrom(toUploadSource(input), remoteFileName);
       await client.send("SITE FILEtype=JES NOJESGETBYDSN");
+      await client.uploadFrom(toUploadSource(input), remoteFileName);
       return await downloadToBuffer(client, remoteFileName);
     } finally {
       client.close();

--- a/tests/job-entry-subsystem.test.ts
+++ b/tests/job-entry-subsystem.test.ts
@@ -83,8 +83,8 @@ describe("JobEntrySubsystem.submitJob", () => {
     expect(client.calls).toEqual([
       "access",
       "send:TYPE A",
-      "uploadFrom:job.jcl",
       "send:SITE FILEtype=JES NOJESGETBYDSN",
+      "uploadFrom:job.jcl",
       "downloadTo:job.jcl",
       "close",
     ]);


### PR DESCRIPTION
## Summary

- Moves `SITE FILEtype=JES NOJESGETBYDSN` before `uploadFrom` in `submitJob` so that the z/OS FTP server interprets the uploaded file as a JES job submission rather than storing it as a regular dataset.
- Updates the corresponding test assertion to reflect the corrected command order.

Closes #9

## Test plan

- [x] `npm test` — all 6 tests pass with the corrected command order
- [x] Test "issues the JES FTP commands in order" now asserts `SITE` precedes `uploadFrom`
- [x] No other tests changed behavior

### Full test output

```
RUN  v2.1.9

 ✓ tests/job-entry-subsystem.test.ts (6 tests) 6ms

 Test Files  1 passed (1)
       Tests  6 passed (6)
   Start at  21:31:44
   Duration  1.48s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)