### PR TITLE
chore: upgrade moduleResolution to node16 (issue #6)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "node16",
     "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

- Changes `tsconfig.json` `moduleResolution` from the deprecated `"node"` to `"node16"`.
- TypeScript 5.x requires `module` to be `"Node16"` when `moduleResolution` is `"node16"`, so both settings are updated together.
- The compiled output is still CommonJS (package.json has no `"type": "module"`), so there is no behavioral change for downstream consumers.

Closes #6

## Test plan

- [x] `npm run build` — compiles without errors
- [x] `dist/index.js` header confirms CommonJS output (`"use strict"; exports...`)
- [x] `npm test` — all 6 tests pass

### Full test output

```
RUN  v2.1.9

 ✓ tests/job-entry-subsystem.test.ts (6 tests) 7ms

 Test Files  1 passed (1)
       Tests  6 passed (6)
   Start at  21:34:38
   Duration  875ms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)