### PR TITLE
feat: add exports field to package.json (issue #7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
   "bugs": {
     "url": "https://github.com/bushidocodes/mainframe-job/issues"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

- Adds an `"exports"` field to `package.json` with a conditional `"types"` / `"default"` entry for the root `.` specifier.
- The legacy `"main"` and `"types"` fields are retained for backward compatibility with older tooling (Node.js <12, older bundlers).

Closes #7

## Test plan

- [x] `npm run build` — no errors
- [x] `npm test` — all 6 tests pass

### Full test output

```
RUN  v2.1.9

 ✓ tests/job-entry-subsystem.test.ts (6 tests) 6ms

 Test Files  1 passed (1)
       Tests  6 passed (6)
   Start at  21:35:23
   Duration  468ms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)