### PR TITLE
feat: type-check examples/ via tsconfig.examples.json (issue #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "lint": "eslint .",
+    "lint": "eslint . && tsc --project tsconfig.examples.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "npm run build"

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "examples"]
+}


### PR DESCRIPTION
## Summary

- Adds `tsconfig.examples.json` (extends `tsconfig.json`, `noEmit: true`, `rootDir: "."`) that covers both `src` and `examples`.
- Wires it into `npm run lint` so `examples/submit-job.ts` is type-checked in CI alongside the main source.

Closes #8

## Test plan

- [x] `tsc --project tsconfig.examples.json` — no errors on the existing example
- [x] `npm run lint` — ESLint + examples type-check both pass
- [x] `npm test` — all 6 tests pass

### Full lint + test output

```
$ npm run lint
> eslint . && tsc --project tsconfig.examples.json
(no errors)

$ npm test
RUN  v2.1.9

 ✓ tests/job-entry-subsystem.test.ts (6 tests) 7ms

 Test Files  1 passed (1)
       Tests  6 passed (6)
   Start at  21:36:34
   Duration  508ms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)