### PR TITLE
fix: add explicit node types for TypeScript 6.0 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "Node16",
     "moduleResolution": "node16",
     "lib": ["ES2022"],
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary

- TypeScript 6.0 dropped implicit inclusion of installed `@types/*` packages as ambient globals
- This caused `Buffer` and `node:stream` to become unresolvable in `src/index.ts` (TS2591 errors)
- Adding `"types": ["node"]` to `tsconfig.json` explicitly opts in, restoring prior behavior

Prerequisite for merging the Dependabot PR [#19](https://github.com/bushidocodes/mainframe-job/pull/19) (typescript 5.9.3 → 6.0.3).

## Test plan

- [x] CI type-check passes on this branch
- [x] After merging, rebase/retrigger PR #19 and confirm its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)