### PR TITLE
feat: migrate to ESM and raise minimum Node to 22

### DIFF
--- a/examples/submit-job.ts
+++ b/examples/submit-job.ts
@@ -9,7 +9,7 @@
  *
  * adjusting the connection options below first.
  */
-import { JobEntrySubsystem } from "../src/index";
+import { JobEntrySubsystem } from "../src/index.js";
 
 const connectionOptions = {
   host: "localhost",
@@ -40,10 +40,10 @@ const jclBuffer = Buffer.from(jclTestJob.replace(/\r?\n/g, "\r\n"), "ascii");
 
 jobEntrySubsystem
   .submitJob(jclBuffer, "tsslist.jcl")
-  .then((output) => {
+  .then((output: Buffer) => {
     console.log(output.toString("ascii"));
   })
-  .catch((error) => {
+  .catch((error: unknown) => {
     console.error("Job submission failed:", error);
     process.exitCode = 1;
   });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ftp",
     "ibm"
   ],
+  "type": "module",
   "license": "ISC",
   "repository": {
     "type": "git",
@@ -32,7 +33,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "node16",
-    "lib": ["ES2022"],
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2024"],
     "types": ["node"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## What changed

- **`package.json`**: Added `"type": "module"` to enable ESM output; raised `engines.node` from `>=18` to `>=22`
- **`tsconfig.json`**: Updated `target`/`lib` from `ES2022` → `ES2024` (Node 22 supports it fully); switched `module`/`moduleResolution` from `Node16`/`node16` → `NodeNext`/`nodenext` (the forward-looking alias, since TypeScript has no `node22` option)
- **`examples/submit-job.ts`**: Fixed the relative import to use an explicit `.js` extension (required by ESM + NodeNext resolution) and added explicit types to `.then`/`.catch` callbacks (required by `strict` mode)

## Why

TypeScript's `module: Node16` compiles to CJS by default — adding `"type": "module"` flips the compiled output to ESM. Raising the Node floor to 22 (current LTS) lets us drop compatibility shims for older releases and target modern ES built-ins.

## Testing

Build, all 6 tests, and lint pass cleanly after the changes.

Closes #24