### PR TITLE
fix: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` at the workflow level in `.github/workflows/ci.yml`
- Fixes CodeQL code-scanning alert [#3](https://github.com/bushidocodes/mainframe-job/security/code-scanning/3) (`actions/missing-workflow-permissions`)

## What changed and why

The CI workflow was relying on the repository's default `GITHUB_TOKEN` permissions, which may be read-write depending on org/repo settings. Adding an explicit `permissions` block with `contents: read` ensures the token is scoped to the minimum required (read-only checkout) regardless of repository or organization defaults — adhering to the principle of least privilege and documenting the actual access needed.

## Reviewer notes

No behaviour change — the workflow steps (install, type-check, lint, test) don't require any write permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)