### PR TITLE
Update TypeScript target and ESLint ecmaVersion to ES2025

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2024",
+    "target": "ES2025",
     "module": "NodeNext",
     "moduleResolution": "nodenext",
-    "lib": ["ES2024"],
+    "lib": ["ES2025"],
     "types": ["node"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary
- Update TypeScript `target` to `ES2025` in all tsconfig files
- Update `lib` arrays to reference `ES2025` instead of older ES versions
- Update ESLint `ecmaVersion` to `2025` where applicable

## Test plan
- [ ] Run `npm run typecheck` (or `pnpm run typecheck`) to verify TypeScript accepts the new target
- [ ] Run `npm run lint` to verify ESLint accepts `ecmaVersion: 2025`

🤖 Generated with [Claude Code](https://claude.com/claude-code)