### PR TITLE
Add Dependabot cooldown (default-days: 3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Summary
- Adds a `cooldown: default-days: 3` block to both `updates` entries (`github-actions`, `npm`) in `.github/dependabot.yml`, so Dependabot waits 3 days after a release before opening a version-bump PR, avoiding same-day exposure to a bad/yanked release.

Fixes #38

## Test plan
- [x] YAML is valid (indentation matches the `schedule` sibling key per the issue's example)
- N/A — config-only change, no build/test surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)